### PR TITLE
Update 2018_11_07_102223_create_countries_table.php

### DIFF
--- a/database/migrations/2018_11_07_102223_create_countries_table.php
+++ b/database/migrations/2018_11_07_102223_create_countries_table.php
@@ -17,8 +17,7 @@ class CreateCountriesTable extends Migration
             $table->increments('id');
             $table->char('iso', 2);
             $table->string('name', 80);
-            $table->string('nicename', 80);
-            $table->char('iso3', 3  )->nullable();
+            $table->char('iso3', 3)->nullable();
             $table->smallinteger('numcode')->nullable();
             $table->integer('phonecode');
         });


### PR DESCRIPTION
Merges `nicename` back into `name` column; see `CountriesSeeder.php` commit message for details